### PR TITLE
Fix Admin-Student and other User-based form validation

### DIFF
--- a/www/src/app/controls/admin/admin-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-dialog.component.ts
@@ -8,7 +8,7 @@ import {MD_DIALOG_DATA} from "@angular/material";
       <admin-administrators-form *ngSwitchCase="'administrators'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-administrators-form>
       <admin-org-administrators-form *ngSwitchCase="'org-administrators'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-org-administrators-form>
       <admin-instructors-form *ngSwitchCase="'instructors'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-instructors-form>
-      <admin-students-form *ngSwitchCase="'students'" [item]="data.item" [adding]="data.adding"></admin-students-form>
+      <admin-students-form *ngSwitchCase="'students'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-students-form>
       <admin-organizations-form *ngSwitchCase="'organizations'" [item]="data.item" [adding]="data.adding"></admin-organizations-form>
       <admin-sessions-form *ngSwitchCase="'sessions'" [item]="data.item" [adding]="data.adding"></admin-sessions-form>
       <admin-programs-form *ngSwitchCase="'programs'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-programs-form>

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
@@ -294,8 +294,6 @@ export class AdminAdministratorsFormComponent implements OnInit {
         Validators.required,
         Validators.pattern(AppConstants.OLValidators.Password)
       ]);
-    } else {
-      this.administratorForm.controls.password.clearValidators();
     }
   }
 

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.ts
@@ -317,8 +317,6 @@ export class AdminInstructorsFormComponent implements OnInit {
         Validators.required,
         Validators.pattern(AppConstants.OLValidators.Password)
       ]);
-    } else {
-      this.instructorForm.controls.password.clearValidators();
     }
   }
 

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.ts
@@ -235,6 +235,7 @@ export class AdminInstructorsFormComponent implements OnInit {
       }
     } else {
       this.instructorForm.markAsTouched();
+      this.updateFormErrors(this.instructorForm, this.formErrors, this.validationMessages);
     }
   }
 

--- a/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.ts
@@ -314,8 +314,6 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
         Validators.required,
         Validators.pattern(AppConstants.OLValidators.Password)
       ]);
-    } else {
-      this.orgAdministratorForm.controls.password.clearValidators();
     }
   }
 

--- a/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.html
@@ -80,10 +80,12 @@
         </md-autocomplete>
         <md-error *ngIf="formErrors.gradeLevel">{{formErrors.gradeLevel}}</md-error>
       </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="organizationId" placeholder="Organization*"/>
+      <div fxLayout="column" fxFlex="30%">
+        <md-select formControlName="organizationId" placeholder="Organization*" [disabled]="!editing">
+          <md-option *ngFor="let organization of organizations" [(value)]="organization.id">{{organization.name}}</md-option>
+        </md-select>
         <md-error *ngIf="formErrors.organizationId">{{formErrors.organizationId}}</md-error>
-      </md-input-container>
+      </div>
       <md-input-container fxFlex="30%">
         <input mdInput formControlName="stateStudentId" placeholder="State Student ID"/>
         <md-error *ngIf="formErrors.stateStudentId">{{formErrors.stateStudentId}}</md-error>

--- a/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.ts
@@ -407,8 +407,6 @@ export class AdminStudentsFormComponent implements OnInit {
         Validators.required,
         Validators.pattern(AppConstants.OLValidators.Password)
       ]);
-    } else {
-      this.studentForm.controls.password.clearValidators();
     }
   }
 

--- a/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.ts
@@ -168,10 +168,10 @@ export class AdminStudentsFormComponent implements OnInit {
         Validators.pattern(AppConstants.OLValidators.Login),
         Validators.maxLength(50)
       ]],
-      password: [this.formStudent.password, this.adding ? [
+      password: [this.formStudent.password, [
         Validators.required,
         Validators.pattern(AppConstants.OLValidators.Password)
-      ] : []],
+      ]],
       notes: [this.formStudent.notes, [
         Validators.maxLength(2000)
       ]],

--- a/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.ts
@@ -21,6 +21,7 @@ export class AdminStudentsFormComponent implements OnInit {
 
   @Input('item') formStudent: any;
   @Input() adding: boolean;
+  @Input('organizations') organizations: any[];
   editing: boolean;
   changingPassword: boolean;
 

--- a/www/src/app/controls/dialog-forms.css
+++ b/www/src/app/controls/dialog-forms.css
@@ -183,6 +183,13 @@ td {
   td:last-child, th:last-child {
     padding-right: 20px;
   }
+
+}
+
+@media only screen and (max-width: 1024px) {
+  md-error.mat-input-error {
+    font-size: 65%;
+  }
 }
 
 .mat-icon.menu-icon {

--- a/www/src/app/pages/student-page/student-page.component.ts
+++ b/www/src/app/pages/student-page/student-page.component.ts
@@ -82,8 +82,7 @@ export class StudentPageComponent implements OnInit {
     },
     password: {
       required: 'Password is required',
-      minlength: 'Password must be at least 6 characters long',
-      maxlength: 'Password cannot be more than 50 characters long'
+      pattern: 'Password must be between 8 and 100 characters and contain at least one letter, one digit, and one of !@#$%^&*()_+'
     },
     notes: {
       maxlength: 'Notes cannot be more than 2000 characters long'
@@ -177,11 +176,10 @@ export class StudentPageComponent implements OnInit {
         Validators.pattern(AppConstants.OLValidators.Login),
         Validators.maxLength(50)
       ]],
-      password: [this.student.password, this.adding ? [
+      password: [this.student.password, [
         Validators.required,
-        Validators.minLength(6),
-        Validators.maxLength(50)
-      ] : []],
+        Validators.pattern(AppConstants.OLValidators.Password)
+      ]],
       email: [this.student.email, [
         // Validators.email, TODO: This forces email to be required, https://github.com/angular/angular/pull/16902 is the fix, pattern below is the workaround
         Validators.pattern(AppConstants.OLValidators.Email),


### PR DESCRIPTION
Fixes #66 #68 

In summary,

- Updates Admin-Student form to use an "Organizations" dropdown for usability
- Fix issue where password validation wasn't being applied or told to the user
- Shrink error message size for smaller screens
- When attempting to save any form, always run validations and update the user of needed changes
- Fix issue where changing an existing Student's password had differing validation rules from backend.