### PR TITLE
Fix: Student Page Details and Editing

### DIFF
--- a/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-students-form/admin-students-form.component.ts
@@ -317,6 +317,7 @@ export class AdminStudentsFormComponent implements OnInit {
       }
     } else {
       this.studentForm.markAsTouched();
+      this.updateFormErrors(this.studentForm, this.formErrors, this.validationMessages);
     }
   }
 

--- a/www/src/app/pages/course-page/course-page.component.ts
+++ b/www/src/app/pages/course-page/course-page.component.ts
@@ -242,6 +242,7 @@ export class CoursePageComponent implements OnInit {
   }
 
   cancel(): void {
+    this.buildForm();
     this.setEditing(this.adding);
   }
 

--- a/www/src/app/pages/student-page/student-page.component.html
+++ b/www/src/app/pages/student-page/student-page.component.html
@@ -76,7 +76,10 @@
         <md-error *ngIf="formErrors.school">{{formErrors.school}}</md-error>
       </md-input-container>
       <md-input-container fxFlex="30%">
-        <input mdInput formControlName="gradeLevel" placeholder="Grade Level*"/>
+        <input mdInput formControlName="gradeLevel" placeholder="Grade Level*" [mdAutocomplete]="gradeLevel"/>
+        <md-autocomplete #gradeLevel="mdAutocomplete" [displayWith]="displayGradeLevel">
+          <md-option *ngFor="let gradeLevel of filteredGradeLevels | async" [(value)]="gradeLevel.value">{{gradeLevel.name}}</md-option>
+        </md-autocomplete>
         <md-error *ngIf="formErrors.gradeLevel">{{formErrors.gradeLevel}}</md-error>
       </md-input-container>
       <div fxLayout="column" fxFlex="30%">

--- a/www/src/app/pages/student-page/student-page.component.html
+++ b/www/src/app/pages/student-page/student-page.component.html
@@ -79,10 +79,12 @@
         <input mdInput formControlName="gradeLevel" placeholder="Grade Level*"/>
         <md-error *ngIf="formErrors.gradeLevel">{{formErrors.gradeLevel}}</md-error>
       </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="organizationId" placeholder="Organization*"/>
+      <div fxLayout="column" fxFlex="30%">
+        <md-select formControlName="organizationId" placeholder="Organization*" [disabled]="!editing">
+          <md-option *ngFor="let organization of organizations" [(value)]="organization.id">{{organization.name}}</md-option>
+        </md-select>
         <md-error *ngIf="formErrors.organizationId">{{formErrors.organizationId}}</md-error>
-      </md-input-container>
+      </div>
       <md-input-container fxFlex="30%">
         <input mdInput formControlName="stateStudentId" placeholder="State Student ID"/>
         <md-error *ngIf="formErrors.stateStudentId">{{formErrors.stateStudentId}}</md-error>

--- a/www/src/app/pages/student-page/student-page.component.ts
+++ b/www/src/app/pages/student-page/student-page.component.ts
@@ -365,6 +365,7 @@ export class StudentPageComponent implements OnInit {
   }
 
   cancel(): void {
+    this.buildForm();
     this.setEditing(this.adding);
     this.resetPassword(false);
   }

--- a/www/src/app/pages/student-page/student-page.component.ts
+++ b/www/src/app/pages/student-page/student-page.component.ts
@@ -36,6 +36,9 @@ export class StudentPageComponent implements OnInit {
   filteredStates: Observable<any[]>;
   private roles: any[];
 
+  organizations:         any[];
+  filteredOrganizations: Observable<any[]>;
+
   filteredInstructors: Observable<any[]>;
   filteredSessions: Observable<any[]>;
 
@@ -160,9 +163,11 @@ export class StudentPageComponent implements OnInit {
     this.setEditing(this.adding);
     this.resetPassword(false);
     this.getStates();
+    this.getOrganizations();
     if(!this.studentView) {
     }
   }
+
   private buildForm(): void {
     this.studentForm = this.fb.group({
       firstName: [this.student.firstName, [
@@ -295,8 +300,22 @@ export class StudentPageComponent implements OnInit {
       .map(val => val ? this.filterStates(val) : this.states.slice());
   }
 
+  private getOrganizations(): void {
+    this.adminService.getAll(AdminTabs.Organization.route).subscribe(resp => {
+      this.organizations = resp;
+      this.filteredOrganizations = this.studentForm.get('organizationId')
+      .valueChanges
+      .startWith(null)
+      .map(val => val ? this.filterOrganizations(val) : this.organizations.slice());
+    });
+  }
+
   private filterStates(val: string): any[] {
     return this.states.filter(state => new RegExp(`${val}`, 'gi').test(state.name));
+  }
+
+  private filterOrganizations(val: string): any[] {
+    return this.organizations.filter(organization => new RegExp(`${val}`, 'gi').test(organization.name));
   }
 
   save(): void {

--- a/www/src/app/pages/student-page/student-page.component.ts
+++ b/www/src/app/pages/student-page/student-page.component.ts
@@ -339,6 +339,7 @@ export class StudentPageComponent implements OnInit {
       }
     } else {
       this.studentForm.markAsTouched();
+      this.updateFormErrors(this.studentForm, this.formErrors, this.validationMessages);
     }
   }
 

--- a/www/src/app/pages/student-page/student-page.component.ts
+++ b/www/src/app/pages/student-page/student-page.component.ts
@@ -186,10 +186,7 @@ export class StudentPageComponent implements OnInit {
         Validators.pattern(AppConstants.OLValidators.Login),
         Validators.maxLength(50)
       ]],
-      password: [this.student.password, [
-        Validators.required,
-        Validators.pattern(AppConstants.OLValidators.Password)
-      ]],
+      password: [this.student.password, []],
       email: [this.student.email, [
         // Validators.email, TODO: This forces email to be required, https://github.com/angular/angular/pull/16902 is the fix, pattern below is the workaround
         Validators.pattern(AppConstants.OLValidators.Email),
@@ -410,6 +407,14 @@ export class StudentPageComponent implements OnInit {
 
   resetPassword(changingPassword: boolean): void {
     this.changingPassword = changingPassword;
+    if (changingPassword) {
+      this.studentForm.controls.password.setValidators([
+        Validators.required,
+        Validators.pattern(AppConstants.OLValidators.Password)
+      ]);
+    } else {
+      this.studentForm.controls.password.clearValidators();
+    }
   }
 
   displayState(stateValue: string): string {

--- a/www/src/app/pages/student-page/student-page.component.ts
+++ b/www/src/app/pages/student-page/student-page.component.ts
@@ -34,10 +34,12 @@ export class StudentPageComponent implements OnInit {
 
   states: any[];
   filteredStates: Observable<any[]>;
+  gradeLevels: any[];
   private roles: any[];
 
   organizations:         any[];
   filteredOrganizations: Observable<any[]>;
+  filteredGradeLevels:   Observable<any[]>;
 
   filteredInstructors: Observable<any[]>;
   filteredSessions: Observable<any[]>;
@@ -163,6 +165,7 @@ export class StudentPageComponent implements OnInit {
     this.setEditing(this.adding);
     this.resetPassword(false);
     this.getStates();
+    this.getGradeLevels();
     this.getOrganizations();
     if(!this.studentView) {
     }
@@ -300,6 +303,14 @@ export class StudentPageComponent implements OnInit {
       .map(val => val ? this.filterStates(val) : this.states.slice());
   }
 
+  private getGradeLevels(): void {
+    this.gradeLevels = AppConstants.GradeLevels;
+    this.filteredGradeLevels = this.studentForm.get('gradeLevel')
+      .valueChanges
+      .startWith(null)
+      .map(val => val ? this.filterGradeLevels(val) : this.gradeLevels.slice());
+  }
+
   private getOrganizations(): void {
     this.adminService.getAll(AdminTabs.Organization.route).subscribe(resp => {
       this.organizations = resp;
@@ -312,6 +323,10 @@ export class StudentPageComponent implements OnInit {
 
   private filterStates(val: string): any[] {
     return this.states.filter(state => new RegExp(`${val}`, 'gi').test(state.name));
+  }
+
+  private filterGradeLevels(val: string): any[] {
+    return this.gradeLevels.filter(gradeLevel => new RegExp(`${val}`, 'gi').test(gradeLevel.name));
   }
 
   private filterOrganizations(val: string): any[] {
@@ -399,6 +414,10 @@ export class StudentPageComponent implements OnInit {
 
   displayState(stateValue: string): string {
     return stateValue ? _.filter(AppConstants.States, {value: stateValue})[0].name : '';
+  }
+
+  displayGradeLevel(gradeLevelValue: string): string {
+    return gradeLevelValue ? _.filter(AppConstants.GradeLevels, {value: gradeLevelValue})[0].name : '';
   }
 
   displayInstructor(instructor: any): string {

--- a/www/src/styles/forms.scss
+++ b/www/src/styles/forms.scss
@@ -12,6 +12,3 @@ div.mat-menu-content {
   padding: 0 !important;
 }
 
-.mat-select-value-text {
-  color: black;
-}


### PR DESCRIPTION
## All Forms

- When canceling an edit, the details in the form are returned to their original state
  - Previously, the edits were left and greyed out.
- Fix dropdown value color when form is disabled

## Student Forms

- Add organization and grade level dropdowns to student edit form
- Fix form not submitting unless changing password
  - Remove password validators by default on student edit page, and only add them when attempting to change password
- Always show errors when attempting to save (if form invalid) for student forms (add and edit)