### PR TITLE
Profile edit without modal

### DIFF
--- a/www/src/app/controls/admin/admin-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-dialog.component.ts
@@ -6,8 +6,8 @@ import {MD_DIALOG_DATA} from "@angular/material";
   template: `
     <div class="admin-dialog" [ngSwitch]="data.tab">
       <admin-administrators-dialog *ngSwitchCase="'administrators'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-administrators-dialog>
-      <admin-org-administrators-form *ngSwitchCase="'org-administrators'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-org-administrators-form>
-      <admin-instructors-form *ngSwitchCase="'instructors'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-instructors-form>
+      <admin-org-administrators-dialog *ngSwitchCase="'org-administrators'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-org-administrators-dialog>
+      <admin-instructors-dialog *ngSwitchCase="'instructors'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-instructors-dialog>
       <admin-students-form *ngSwitchCase="'students'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-students-form>
       <admin-organizations-form *ngSwitchCase="'organizations'" [item]="data.item" [adding]="data.adding"></admin-organizations-form>
       <admin-sessions-form *ngSwitchCase="'sessions'" [item]="data.item" [adding]="data.adding"></admin-sessions-form>

--- a/www/src/app/controls/admin/admin-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-dialog.component.ts
@@ -5,7 +5,7 @@ import {MD_DIALOG_DATA} from "@angular/material";
   selector: 'admin-dialog',
   template: `
     <div class="admin-dialog" [ngSwitch]="data.tab">
-      <admin-administrators-form *ngSwitchCase="'administrators'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-administrators-form>
+      <admin-administrators-dialog *ngSwitchCase="'administrators'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-administrators-dialog>
       <admin-org-administrators-form *ngSwitchCase="'org-administrators'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-org-administrators-form>
       <admin-instructors-form *ngSwitchCase="'instructors'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-instructors-form>
       <admin-students-form *ngSwitchCase="'students'" [item]="data.item" [adding]="data.adding" [organizations]="data.organizations"></admin-students-form>

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.html
@@ -1,4 +1,4 @@
-<div>
+<form [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
   <div class="ol-dialog-header" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
     <div fxLayout="row" fxLayoutAlign="start center">
       <div><button md-button type="reset" (click)="close()"><i class="fa fa-times fa-lg"></i></button></div>
@@ -7,7 +7,7 @@
       <span class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Administrator</span>
     </div>
     <div fxLayout="row">
-      <button md-raised-button type="submit" *ngIf="editing" (click)="adminForm.save()" class="ol-dialog-button grey-button" mdTooltip="Save">
+      <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
         <md-icon>save</md-icon>
       </button>
       <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
@@ -26,7 +26,7 @@
       </md-menu>
     </div>
   </div>
-  <admin-administrators-form #adminForm [item]="formAdministrator" [adding]="adding" [organizations]="organizations"
+  <admin-administrators-form #adminForm [fg]="administratorForm" [item]="formAdministrator" [adding]="adding" [organizations]="organizations"
                              (onAdd)="added($event)" (onUpdate)="updated($event)" (onDelete)="deleted()" (onEdit)="updateEditing($event)">
   </admin-administrators-form>
-</div>
+</form>

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.html
@@ -1,0 +1,32 @@
+<div>
+  <div class="ol-dialog-header" [ngClass]="{edit: adminForm.editing}" fxLayout="row" fxLayoutAlign="space-between center">
+    <div fxLayout="row" fxLayoutAlign="start center">
+      <div><button md-button type="reset" (click)="close()"><i class="fa fa-times fa-lg"></i></button></div>
+      <span class="ol-dialog-title" *ngIf="!adminForm.editing">Administrator Details</span>
+      <span class="ol-dialog-title edit" *ngIf="adminForm.adding">New Administrator</span>
+      <span class="ol-dialog-title edit" *ngIf="adminForm.editing && !adminForm.adding">Edit Administrator</span>
+    </div>
+    <div fxLayout="row">
+      <button md-raised-button type="button" *ngIf="adminForm.editing" (click)="adminForm.save()" class="ol-dialog-button grey-button" mdTooltip="Save">
+        <md-icon>save</md-icon>
+      </button>
+      <button md-raised-button type="reset" *ngIf="adminForm.editing && !adminForm.adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+        <md-icon>clear</md-icon>
+      </button>
+      <button md-raised-button type="button" *ngIf="!adminForm.editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+        <md-icon>create</md-icon>
+      </button>
+      <button md-raised-button type="button" *ngIf="!adminForm.editing" [mdMenuTriggerFor]="deleteMenu" class="ol-dialog-button pink-button" mdTooltip="Delete">
+        <md-icon>delete</md-icon>
+      </button>
+      <md-menu #deleteMenu="mdMenu">
+        <button md-menu-item type="button" disabled class="pink-button">Are you sure?</button>
+        <button md-menu-item type="button" (click)="adminForm.delete()">Yes, delete it</button>
+        <button md-menu-item type="button">No, go back</button>
+      </md-menu>
+    </div>
+  </div>
+  <admin-administrators-form #adminForm [item]="formAdministrator" [adding]="adding" [organizations]="organizations"
+                             (onAdd)="added($event)" (onUpdate)="updated($event)" (onDelete)="deleted()">
+  </admin-administrators-form>
+</div>

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.html
@@ -1,22 +1,22 @@
 <div>
-  <div class="ol-dialog-header" [ngClass]="{edit: adminForm.editing}" fxLayout="row" fxLayoutAlign="space-between center">
+  <div class="ol-dialog-header" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
     <div fxLayout="row" fxLayoutAlign="start center">
       <div><button md-button type="reset" (click)="close()"><i class="fa fa-times fa-lg"></i></button></div>
-      <span class="ol-dialog-title" *ngIf="!adminForm.editing">Administrator Details</span>
-      <span class="ol-dialog-title edit" *ngIf="adminForm.adding">New Administrator</span>
-      <span class="ol-dialog-title edit" *ngIf="adminForm.editing && !adminForm.adding">Edit Administrator</span>
+      <span class="ol-dialog-title" *ngIf="!editing">Administrator Details</span>
+      <span class="ol-dialog-title edit" *ngIf="adding">New Administrator</span>
+      <span class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Administrator</span>
     </div>
     <div fxLayout="row">
-      <button md-raised-button type="button" *ngIf="adminForm.editing" (click)="adminForm.save()" class="ol-dialog-button grey-button" mdTooltip="Save">
+      <button md-raised-button type="submit" *ngIf="editing" (click)="adminForm.save()" class="ol-dialog-button grey-button" mdTooltip="Save">
         <md-icon>save</md-icon>
       </button>
-      <button md-raised-button type="reset" *ngIf="adminForm.editing && !adminForm.adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
         <md-icon>clear</md-icon>
       </button>
-      <button md-raised-button type="button" *ngIf="!adminForm.editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+      <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
         <md-icon>create</md-icon>
       </button>
-      <button md-raised-button type="button" *ngIf="!adminForm.editing" [mdMenuTriggerFor]="deleteMenu" class="ol-dialog-button pink-button" mdTooltip="Delete">
+      <button md-raised-button type="button" *ngIf="!editing" [mdMenuTriggerFor]="deleteMenu" class="ol-dialog-button pink-button" mdTooltip="Delete">
         <md-icon>delete</md-icon>
       </button>
       <md-menu #deleteMenu="mdMenu">
@@ -27,6 +27,6 @@
     </div>
   </div>
   <admin-administrators-form #adminForm [item]="formAdministrator" [adding]="adding" [organizations]="organizations"
-                             (onAdd)="added($event)" (onUpdate)="updated($event)" (onDelete)="deleted()">
+                             (onAdd)="added($event)" (onUpdate)="updated($event)" (onDelete)="deleted()" (onEdit)="updateEditing($event)">
   </admin-administrators-form>
 </div>

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.ts
@@ -1,0 +1,47 @@
+import {Component, Input, OnInit} from "@angular/core";
+import {MdDialogRef} from "@angular/material";
+
+import {AdminDialogComponent} from "../../admin-dialog.component";
+import {Admin} from "../../../../models/admin.model";
+
+@Component({
+  selector: 'admin-administrators-dialog',
+  templateUrl: './admin-administrators-dialog.component.html',
+  styleUrls: ['../../../dialog-forms.css']
+})
+export class AdminAdministratorsDialogComponent {
+
+  @Input('item') formAdministrator: Admin;
+  @Input() adding: boolean;
+  @Input('organizations') organizations: any[];
+
+  constructor(public dialogRef: MdDialogRef<AdminDialogComponent>) {}
+
+  added(account: Account): void {
+    this.dialogRef.close({
+      type: 'ADD',
+      data: account
+    });
+  };
+
+  updated(account: Account): void {
+    this.dialogRef.close({
+      type: 'UPDATE',
+      data: account
+    });
+  }
+
+  deleted(): void {
+    this.dialogRef.close({
+      type: 'DELETE',
+      data: {
+        id: this.formAdministrator.id
+      }
+    });
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+
+}

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.ts
@@ -1,25 +1,35 @@
-import {Component, Input} from "@angular/core";
+import {Component, Input, OnInit} from "@angular/core";
 import {MdDialogRef} from "@angular/material";
 
 import {AdminDialogComponent} from "../../admin-dialog.component";
 import {Admin} from "../../../../models/admin.model";
+import {FormGroup} from "@angular/forms";
 
 @Component({
   selector: 'admin-administrators-dialog',
   templateUrl: './admin-administrators-dialog.component.html',
   styleUrls: ['../../../dialog-forms.css']
 })
-export class AdminAdministratorsDialogComponent {
+export class AdminAdministratorsDialogComponent implements OnInit {
 
   @Input('item') formAdministrator: Admin;
   @Input() adding: boolean;
   @Input('organizations') organizations: any[];
 
   editing: boolean = false;
+  administratorForm: FormGroup;
 
-  constructor(public dialogRef: MdDialogRef<AdminDialogComponent>) {}
+  constructor(public dialogRef: MdDialogRef<AdminDialogComponent>) {
+    this.administratorForm = new FormGroup({});
+  }
 
+  ngOnInit(): void {
+    this.editing = this.adding;
+  }
+
+  // TODO: Convert this to a 'status' of EDITING, ADDING, VIEWING, etc
   updateEditing(isEditing: boolean): void {
+    console.log('updateEditing', isEditing);
     this.editing = isEditing;
   };
 

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from "@angular/core";
+import {Component, Input} from "@angular/core";
 import {MdDialogRef} from "@angular/material";
 
 import {AdminDialogComponent} from "../../admin-dialog.component";
@@ -15,7 +15,13 @@ export class AdminAdministratorsDialogComponent {
   @Input() adding: boolean;
   @Input('organizations') organizations: any[];
 
+  editing: boolean = false;
+
   constructor(public dialogRef: MdDialogRef<AdminDialogComponent>) {}
+
+  updateEditing(isEditing: boolean): void {
+    this.editing = isEditing;
+  };
 
   added(account: Account): void {
     this.dialogRef.close({

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-dialog/admin-administrators-dialog.component.ts
@@ -27,7 +27,6 @@ export class AdminAdministratorsDialogComponent implements OnInit {
     this.editing = this.adding;
   }
 
-  // TODO: Convert this to a 'status' of EDITING, ADDING, VIEWING, etc
   updateEditing(isEditing: boolean): void {
     this.editing = isEditing;
   };

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.html
@@ -1,31 +1,4 @@
 <form [formGroup]="administratorForm" (ngSubmit)="save()" novalidate>
-  <div class="ol-dialog-header" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
-    <div fxLayout="row" fxLayoutAlign="start center">
-      <div><button md-button type="reset" (click)="close()"><i class="fa fa-times fa-lg"></i></button></div>
-      <span class="ol-dialog-title" *ngIf="!editing">Administrator Details</span>
-      <span class="ol-dialog-title edit" *ngIf="adding">New Administrator</span>
-      <span class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Administrator</span>
-    </div>
-    <div fxLayout="row">
-      <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
-        <md-icon>save</md-icon>
-      </button>
-      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
-        <md-icon>clear</md-icon>
-      </button>
-      <button md-raised-button type="button" *ngIf="!editing" (click)="edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
-        <md-icon>create</md-icon>
-      </button>
-      <button md-raised-button type="button" *ngIf="!editing" [mdMenuTriggerFor]="deleteMenu" class="ol-dialog-button pink-button" mdTooltip="Delete">
-        <md-icon>delete</md-icon>
-      </button>
-      <md-menu #deleteMenu="mdMenu">
-        <button md-menu-item type="button" disabled class="pink-button">Are you sure?</button>
-        <button md-menu-item type="button" (click)="delete()">Yes, delete it</button>
-        <button md-menu-item type="button">No, go back</button>
-      </md-menu>
-    </div>
-  </div>
   <div class="ol-dialog-content">
     <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutWrap>
       <md-input-container fxFlex="30%">

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.html
@@ -1,63 +1,61 @@
-<form [formGroup]="administratorForm" (ngSubmit)="save()" (keyup)="save()" novalidate>
-  <div class="ol-dialog-content">
-    <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutWrap>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="firstName" placeholder="First Name*"/>
-        <md-error *ngIf="formErrors.firstName">{{formErrors.firstName}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="lastName" placeholder="Last Name*"/>
-        <md-error *ngIf="formErrors.lastName">{{formErrors.lastName}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="login" placeholder="Username*"/>
-        <md-error *ngIf="formErrors.login">{{formErrors.login}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%" *ngIf="adding">
-        <input mdInput formControlName="password" placeholder="Password*"/>
-        <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <textarea mdInput formControlName="notes" placeholder="Notes"></textarea>
-        <md-error *ngIf="formErrors.notes">{{formErrors.notes}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="email" placeholder="Email"/>
-        <md-error *ngIf="formErrors.email">{{formErrors.email}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="streetAddress1" placeholder="Address 1"/>
-        <md-error *ngIf="formErrors.streetAddress1">{{formErrors.streetAddress1}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="streetAddress2" placeholder="Address 2"/>
-        <md-error *ngIf="formErrors.streetAddress2">{{formErrors.streetAddress2}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="city" placeholder="City"/>
-        <md-error *ngIf="formErrors.city">{{formErrors.city}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="state" placeholder="State" [mdAutocomplete]="state"/>
-        <md-autocomplete #state="mdAutocomplete" [displayWith]="displayState">
-          <md-option *ngFor="let state of filteredStates | async" [value]="state.value">{{state.name}}</md-option>
-        </md-autocomplete>
-      </md-input-container>
-      <md-input-container fxFlex="25%">
-        <input mdInput formControlName="phoneNumber" placeholder="Phone"/>
-        <md-error *ngIf="formErrors.phoneNumber">{{formErrors.phoneNumber}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="postalCode" placeholder="Postal Code"/>
-        <md-error *ngIf="formErrors.postalCode">{{formErrors.postalCode}}</md-error>
-      </md-input-container>
-      <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
-        <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
-      </div>
-      <md-input-container fxFlex="30%" *ngIf="changingPassword">
-        <input mdInput formControlName="password" placeholder="New Password"/>
-        <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
-      </md-input-container>
+<div [formGroup]="administratorForm" class="ol-dialog-content">
+  <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutWrap>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="firstName" placeholder="First Name*"/>
+      <md-error *ngIf="formErrors.firstName">{{formErrors.firstName}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="lastName" placeholder="Last Name*"/>
+      <md-error *ngIf="formErrors.lastName">{{formErrors.lastName}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="login" placeholder="Username*"/>
+      <md-error *ngIf="formErrors.login">{{formErrors.login}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%" *ngIf="adding">
+      <input mdInput formControlName="password" placeholder="Password*"/>
+      <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <textarea mdInput formControlName="notes" placeholder="Notes"></textarea>
+      <md-error *ngIf="formErrors.notes">{{formErrors.notes}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="email" placeholder="Email"/>
+      <md-error *ngIf="formErrors.email">{{formErrors.email}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="streetAddress1" placeholder="Address 1"/>
+      <md-error *ngIf="formErrors.streetAddress1">{{formErrors.streetAddress1}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="streetAddress2" placeholder="Address 2"/>
+      <md-error *ngIf="formErrors.streetAddress2">{{formErrors.streetAddress2}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="city" placeholder="City"/>
+      <md-error *ngIf="formErrors.city">{{formErrors.city}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="state" placeholder="State" [mdAutocomplete]="state"/>
+      <md-autocomplete #state="mdAutocomplete" [displayWith]="displayState">
+        <md-option *ngFor="let state of filteredStates | async" [value]="state.value">{{state.name}}</md-option>
+      </md-autocomplete>
+    </md-input-container>
+    <md-input-container fxFlex="25%">
+      <input mdInput formControlName="phoneNumber" placeholder="Phone"/>
+      <md-error *ngIf="formErrors.phoneNumber">{{formErrors.phoneNumber}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="postalCode" placeholder="Postal Code"/>
+      <md-error *ngIf="formErrors.postalCode">{{formErrors.postalCode}}</md-error>
+    </md-input-container>
+    <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
+      <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
     </div>
+    <md-input-container fxFlex="30%" *ngIf="changingPassword">
+      <input mdInput formControlName="password" placeholder="New Password"/>
+      <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
+    </md-input-container>
   </div>
-</form>
+</div>

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="administratorForm" (ngSubmit)="save()" novalidate>
+<form [formGroup]="administratorForm" (ngSubmit)="save()" (keyup)="save()" novalidate>
   <div class="ol-dialog-content">
     <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutWrap>
       <md-input-container fxFlex="30%">

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.html
@@ -51,7 +51,7 @@
       <md-error *ngIf="formErrors.postalCode">{{formErrors.postalCode}}</md-error>
     </md-input-container>
     <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
-      <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
+      <button md-raised-button type="button" (click)="resetPassword(true)" class="reset-password">Change Password</button>
     </div>
     <md-input-container fxFlex="30%" *ngIf="changingPassword">
       <input mdInput formControlName="password" placeholder="New Password"/>

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
@@ -1,5 +1,5 @@
-import {Component, Input, OnInit, EventEmitter, Output} from "@angular/core";
-import {AbstractControl, FormBuilder, FormGroup, Validators} from "@angular/forms";
+import {Component, EventEmitter, Input, OnInit, Output} from "@angular/core";
+import {FormBuilder, FormGroup, Validators} from "@angular/forms";
 import {Observable} from "rxjs/Observable";
 import * as _ from "lodash";
 
@@ -20,7 +20,7 @@ export class AdminAdministratorsFormComponent implements OnInit {
   @Input('item') formAdministrator: Admin;
   @Input() adding: boolean;
   @Input('organizations') organizations: any[];
-  @Input('fg') administratorForm: FormGroup; // TODO: See about giving this a better name
+  @Input('parent') administratorForm: FormGroup;
 
   @Output() onAdd = new EventEmitter<Account>();
   @Output() onUpdate = new EventEmitter<Account>();
@@ -35,7 +35,6 @@ export class AdminAdministratorsFormComponent implements OnInit {
 
   filteredStates: Observable<any[]>;
 
-  // administratorForm: FormGroup;
   formErrors = {
     firstName: '',
     lastName: '',
@@ -55,7 +54,7 @@ export class AdminAdministratorsFormComponent implements OnInit {
       maxlength: 'First Name cannot be more than 50 characters long'
     },
     lastName: {
-      required: 'First Name is required',
+      required: 'Last Name is required',
       maxlength: 'Last Name cannot be more than 50 characters long'
     },
     login: {
@@ -225,11 +224,10 @@ export class AdminAdministratorsFormComponent implements OnInit {
       }
     } else {
       this.administratorForm.markAsTouched();
-      console.log('submitted', this.administratorForm.getRawValue()._submitted);
-      // // TODO: See if this is necessary
       for (let key in this.administratorForm.controls) {
-        const element = this.administratorForm.controls[key];
-        element.markAsTouched();
+        // TODO: MD - Try to take this out at some point
+        // TODO: MD - The child form doesn't show up at submitted, so the validation errors won't show
+        this.administratorForm.controls[key].markAsTouched();
       }
     }
   }

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
@@ -108,13 +108,13 @@ export class AdminAdministratorsFormComponent implements OnInit {
     this.getStates();
   }
 
-  changingPasswordValidators(c: AbstractControl): ValidationErrors {
+  changingPasswordValidators(control: AbstractControl): ValidationErrors {
     if (this.changingPassword) {
       const validators = Validators.compose([
           Validators.required,
           Validators.pattern(AppConstants.OLValidators.Password)
       ]);
-      return validators(c);
+      return validators(control);
     } else {
       return null;
     }

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
@@ -25,6 +25,7 @@ export class AdminAdministratorsFormComponent implements OnInit {
   @Output() onAdd = new EventEmitter<Account>();
   @Output() onUpdate = new EventEmitter<Account>();
   @Output() onDelete = new EventEmitter();
+  @Output() onEdit = new EventEmitter<boolean>();
 
   editing: boolean;
   changingPassword: boolean;
@@ -217,7 +218,9 @@ export class AdminAdministratorsFormComponent implements OnInit {
       }
     } else {
       this.administratorForm.markAsTouched();
-      this.administratorForm.markAsDirty();
+      for (let key in this.administratorForm.controls) {
+        this.administratorForm.controls[key].markAsTouched();
+      }
     }
   }
 
@@ -270,10 +273,12 @@ export class AdminAdministratorsFormComponent implements OnInit {
 
   edit(): void {
     this.setEditing(true);
+    this.onEdit.emit(true);
   }
 
   cancel(): void {
     this.ngOnInit();
+    this.onEdit.emit(false);
   }
 
   resetPassword(changingPassword: boolean): void {

--- a/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-administrators-form/admin-administrators-form.component.ts
@@ -168,7 +168,6 @@ export class AdminAdministratorsFormComponent implements OnInit {
         Validators.pattern(AppConstants.OLValidators.PostalCode)
       ]]
     });
-    // TODO: See if this is necessary
     for (let key in childForm.controls) {
       this.administratorForm.addControl(key, childForm.get(key));
     }

--- a/www/src/app/controls/admin/admin-forms/admin-forms.module.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-forms.module.ts
@@ -16,6 +16,8 @@ import {AdminProgramsFormComponent} from "./admin-programs-form/admin-programs-f
 import {AdminSessionsFormComponent} from "./admin-sessions-form/admin-sessions-form.component";
 import {AdminStudentsFormComponent} from "./admin-students-form/admin-students-form.component";
 import {AdminAdministratorsDialogComponent} from "./admin-administrators-dialog/admin-administrators-dialog.component";
+import {AdminOrgAdministratorsDialogComponent} from "./admin-org-administrators-dialog/admin-org-administrators-dialog.component";
+import {AdminInstructorsDialogComponent} from "./admin-instructors-dialog/admin-instructors-dialog.component";
 
 @NgModule({
   declarations: [
@@ -24,8 +26,10 @@ import {AdminAdministratorsDialogComponent} from "./admin-administrators-dialog/
     AdminAdministratorsDialogComponent,
     AdminCoursesFormComponent,
     AdminInstructorsFormComponent,
+    AdminInstructorsDialogComponent,
     // AdminMilestonesFormComponent,
     AdminOrgAdministratorsFormComponent,
+    AdminOrgAdministratorsDialogComponent,
     AdminOrganizationsFormComponent,
     AdminProgramsFormComponent,
     AdminSessionsFormComponent,
@@ -52,8 +56,10 @@ import {AdminAdministratorsDialogComponent} from "./admin-administrators-dialog/
     AdminAdministratorsDialogComponent,
     AdminCoursesFormComponent,
     AdminInstructorsFormComponent,
+    AdminInstructorsDialogComponent,
     // AdminMilestonesFormComponent,
     AdminOrgAdministratorsFormComponent,
+    AdminOrgAdministratorsDialogComponent,
     AdminOrganizationsFormComponent,
     AdminProgramsFormComponent,
     AdminSessionsFormComponent,

--- a/www/src/app/controls/admin/admin-forms/admin-forms.module.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-forms.module.ts
@@ -15,11 +15,13 @@ import {AdminOrganizationsFormComponent} from "./admin-organizations-form/admin-
 import {AdminProgramsFormComponent} from "./admin-programs-form/admin-programs-form.component";
 import {AdminSessionsFormComponent} from "./admin-sessions-form/admin-sessions-form.component";
 import {AdminStudentsFormComponent} from "./admin-students-form/admin-students-form.component";
+import {AdminAdministratorsDialogComponent} from "./admin-administrators-dialog/admin-administrators-dialog.component";
 
 @NgModule({
   declarations: [
     // AdminAchievementsFormComponent,
     AdminAdministratorsFormComponent,
+    AdminAdministratorsDialogComponent,
     AdminCoursesFormComponent,
     AdminInstructorsFormComponent,
     // AdminMilestonesFormComponent,
@@ -47,6 +49,7 @@ import {AdminStudentsFormComponent} from "./admin-students-form/admin-students-f
   exports: [
     // AdminAchievementsFormComponent,
     AdminAdministratorsFormComponent,
+    AdminAdministratorsDialogComponent,
     AdminCoursesFormComponent,
     AdminInstructorsFormComponent,
     // AdminMilestonesFormComponent,

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-dialog/admin-instructors-dialog.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-dialog/admin-instructors-dialog.component.html
@@ -1,0 +1,32 @@
+<form [formGroup]="instructorForm" (ngSubmit)="instructForm.save()" novalidate>
+  <div class="ol-dialog-header" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
+    <div fxLayout="row" fxLayoutAlign="start center">
+      <div><button md-button type="reset" (click)="close()"><i class="fa fa-times fa-lg"></i></button></div>
+      <span class="ol-dialog-title" *ngIf="!editing">Instructor Details</span>
+      <span class="ol-dialog-title edit" *ngIf="adding">New Instructor</span>
+      <span class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Instructor</span>
+    </div>
+    <div fxLayout="row">
+      <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
+        <md-icon>save</md-icon>
+      </button>
+      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="instructForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+        <md-icon>clear</md-icon>
+      </button>
+      <button md-raised-button type="button" *ngIf="!isInstructor && !editing" (click)="instructForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+        <md-icon>create</md-icon>
+      </button>
+      <button md-raised-button type="button" *ngIf="!isInstructor && !editing" [mdMenuTriggerFor]="deleteMenu" class="ol-dialog-button pink-button" mdTooltip="Delete">
+        <md-icon>delete</md-icon>
+      </button>
+      <md-menu #deleteMenu="mdMenu">
+        <button md-menu-item type="button" disabled class="pink-button">Are you sure?</button>
+        <button md-menu-item type="button" (click)="instructForm.delete()">Yes, delete it</button>
+        <button md-menu-item type="button">No, go back</button>
+      </md-menu>
+    </div>
+  </div>
+  <admin-instructors-form #instructForm [parent]="instructorForm" [item]="formInstructor" [adding]="adding" [organizations]="organizations"
+                          (onAdd)="added($event)" (onUpdate)="updated($event)" (onDelete)="deleted()" (onEdit)="updateEditing($event)">
+  </admin-instructors-form>
+</form>

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-dialog/admin-instructors-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-dialog/admin-instructors-dialog.component.ts
@@ -32,7 +32,7 @@ export class AdminInstructorsDialogComponent implements OnInit {
   ngOnInit(): void {
     this.editing = this.adding;
   }
-  // TODO: Convert this to a 'status' of EDITING, ADDING, VIEWING, etc
+
   updateEditing(isEditing: boolean): void {
     this.editing = isEditing;
   };

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-dialog/admin-instructors-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-dialog/admin-instructors-dialog.component.ts
@@ -1,32 +1,37 @@
 import {Component, Input, OnInit} from "@angular/core";
+import {FormBuilder, FormGroup, Validators} from "@angular/forms";
 import {MdDialogRef} from "@angular/material";
+import {Observable} from "rxjs/Observable";
+import * as _ from "lodash";
 
 import {AdminDialogComponent} from "../../admin-dialog.component";
-import {Admin} from "../../../../models/admin.model";
-import {FormGroup} from "@angular/forms";
+import {AppConstants} from "../../../../app.constants";
+import {AdminTabs} from "../../admin.constants";
+import {NotifyService} from "../../../../services/notify.service";
+import {AdminService} from "../../../../services/admin.service";
+import {Principal} from "../../../../shared/auth/principal-storage.service";
 
 @Component({
-  selector: 'admin-administrators-dialog',
-  templateUrl: './admin-administrators-dialog.component.html',
+  selector: 'admin-instructors-dialog',
+  templateUrl: './admin-instructors-dialog.component.html',
   styleUrls: ['../../../dialog-forms.css']
 })
-export class AdminAdministratorsDialogComponent implements OnInit {
+export class AdminInstructorsDialogComponent implements OnInit {
 
-  @Input('item') formAdministrator: Admin;
+  @Input('item') formInstructor: any;
   @Input() adding: boolean;
   @Input('organizations') organizations: any[];
 
-  editing: boolean = false;
-  administratorForm: FormGroup;
+  editing: boolean;
+  instructorForm: FormGroup;
 
   constructor(public dialogRef: MdDialogRef<AdminDialogComponent>) {
-    this.administratorForm = new FormGroup({});
+    this.instructorForm = new FormGroup({});
   }
 
   ngOnInit(): void {
     this.editing = this.adding;
   }
-
   // TODO: Convert this to a 'status' of EDITING, ADDING, VIEWING, etc
   updateEditing(isEditing: boolean): void {
     this.editing = isEditing;
@@ -50,7 +55,7 @@ export class AdminAdministratorsDialogComponent implements OnInit {
     this.dialogRef.close({
       type: 'DELETE',
       data: {
-        id: this.formAdministrator.id
+        id: this.formInstructor.id
       }
     });
   }

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.html
@@ -61,7 +61,7 @@
       <md-error *ngIf="formErrors.orgRole">{{formErrors.orgRole}}</md-error>
     </md-input-container>
     <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
-      <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
+      <button md-raised-button type="button" (click)="resetPassword(true)" class="reset-password">Change Password</button>
     </div>
     <md-input-container fxFlex="30%" *ngIf="changingPassword">
       <input mdInput formControlName="password" placeholder="New Password"/>

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.html
@@ -1,100 +1,71 @@
-<form [formGroup]="instructorForm" (ngSubmit)="save()" novalidate>
-  <div class="ol-dialog-header" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
-    <div fxLayout="row" fxLayoutAlign="start center">
-      <div><button md-button type="reset" (click)="close()"><i class="fa fa-times fa-lg"></i></button></div>
-      <span class="ol-dialog-title" *ngIf="!editing">Instructor Details</span>
-      <span class="ol-dialog-title edit" *ngIf="adding">New Instructor</span>
-      <span class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Instructor</span>
+<div [formGroup]="instructorForm" class="ol-dialog-content">
+  <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutWrap>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="firstName" placeholder="First Name*"/>
+      <md-error *ngIf="formErrors.firstName">{{formErrors.firstName}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="lastName" placeholder="Last Name*"/>
+      <md-error *ngIf="formErrors.lastName">{{formErrors.lastName}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="login" placeholder="Username*"/>
+      <md-error *ngIf="formErrors.login">{{formErrors.login}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%" *ngIf="adding">
+      <input mdInput formControlName="password" placeholder="Password*"/>
+      <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <textarea mdInput formControlName="notes" placeholder="Notes"></textarea>
+      <md-error *ngIf="formErrors.notes">{{formErrors.notes}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="email" placeholder="Email"/>
+      <md-error *ngIf="formErrors.email">{{formErrors.email}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="streetAddress1" placeholder="Address 1"/>
+      <md-error *ngIf="formErrors.streetAddress1">{{formErrors.streetAddress1}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="streetAddress2" placeholder="Address 2"/>
+      <md-error *ngIf="formErrors.streetAddress2">{{formErrors.streetAddress2}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="city" placeholder="City"/>
+      <md-error *ngIf="formErrors.city">{{formErrors.city}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="state" placeholder="State" [mdAutocomplete]="state"/>
+      <md-autocomplete #state="mdAutocomplete" [displayWith]="displayState">
+        <md-option *ngFor="let state of filteredStates | async" [value]="state.value">{{state.name}}</md-option>
+      </md-autocomplete>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="phoneNumber" placeholder="Phone"/>
+      <md-error *ngIf="formErrors.phoneNumber">{{formErrors.phoneNumber}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="postalCode" placeholder="Postal Code"/>
+      <md-error *ngIf="formErrors.postalCode">{{formErrors.postalCode}}</md-error>
+    </md-input-container>
+    <div fxLayout="column" fxFlex="20%">
+      <md-error *ngIf="formErrors.organizationId">{{formErrors.organizationId}}</md-error>
+      <md-select formControlName="organizationId" placeholder="Organization*" [disabled]="!editing">
+        <md-option *ngFor="let organization of organizations" [(value)]="organization.id">{{organization.name}}</md-option>
+      </md-select>
     </div>
-    <div fxLayout="row">
-      <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
-        <md-icon>save</md-icon>
-      </button>
-      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
-        <md-icon>clear</md-icon>
-      </button>
-      <button md-raised-button type="button" *ngIf="!isInstructor && !editing" (click)="edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
-        <md-icon>create</md-icon>
-      </button>
-      <button md-raised-button type="button" *ngIf="!isInstructor && !editing" [mdMenuTriggerFor]="deleteMenu" class="ol-dialog-button pink-button" mdTooltip="Delete">
-        <md-icon>delete</md-icon>
-      </button>
-      <md-menu #deleteMenu="mdMenu">
-        <button md-menu-item type="button" disabled class="pink-button">Are you sure?</button>
-        <button md-menu-item type="button" (click)="delete()">Yes, delete it</button>
-        <button md-menu-item type="button">No, go back</button>
-      </md-menu>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="orgRole" placeholder="Org Role*"/>
+      <md-error *ngIf="formErrors.orgRole">{{formErrors.orgRole}}</md-error>
+    </md-input-container>
+    <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
+      <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
     </div>
+    <md-input-container fxFlex="30%" *ngIf="changingPassword">
+      <input mdInput formControlName="password" placeholder="New Password"/>
+      <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
+    </md-input-container>
   </div>
-  <div class="ol-dialog-content">
-    <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutWrap>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="firstName" placeholder="First Name*"/>
-        <md-error *ngIf="formErrors.firstName">{{formErrors.firstName}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="lastName" placeholder="Last Name*"/>
-        <md-error *ngIf="formErrors.lastName">{{formErrors.lastName}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="login" placeholder="Username*"/>
-        <md-error *ngIf="formErrors.login">{{formErrors.login}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%" *ngIf="adding">
-        <input mdInput formControlName="password" placeholder="Password*"/>
-        <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <textarea mdInput formControlName="notes" placeholder="Notes"></textarea>
-        <md-error *ngIf="formErrors.notes">{{formErrors.notes}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="email" placeholder="Email"/>
-        <md-error *ngIf="formErrors.email">{{formErrors.email}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="streetAddress1" placeholder="Address 1"/>
-        <md-error *ngIf="formErrors.streetAddress1">{{formErrors.streetAddress1}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="streetAddress2" placeholder="Address 2"/>
-        <md-error *ngIf="formErrors.streetAddress2">{{formErrors.streetAddress2}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="city" placeholder="City"/>
-        <md-error *ngIf="formErrors.city">{{formErrors.city}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="state" placeholder="State" [mdAutocomplete]="state"/>
-        <md-autocomplete #state="mdAutocomplete" [displayWith]="displayState">
-          <md-option *ngFor="let state of filteredStates | async" [value]="state.value">{{state.name}}</md-option>
-        </md-autocomplete>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="phoneNumber" placeholder="Phone"/>
-        <md-error *ngIf="formErrors.phoneNumber">{{formErrors.phoneNumber}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="postalCode" placeholder="Postal Code"/>
-        <md-error *ngIf="formErrors.postalCode">{{formErrors.postalCode}}</md-error>
-      </md-input-container>
-      <div fxLayout="column" fxFlex="20%">
-        <md-error *ngIf="formErrors.organizationId">{{formErrors.organizationId}}</md-error>
-        <md-select formControlName="organizationId" placeholder="Organization*" [disabled]="!editing">
-          <md-option *ngFor="let organization of organizations" [(value)]="organization.id">{{organization.name}}</md-option>
-        </md-select>
-      </div>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="orgRole" placeholder="Org Role*"/>
-        <md-error *ngIf="formErrors.orgRole">{{formErrors.orgRole}}</md-error>
-      </md-input-container>
-      <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
-        <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
-      </div>
-      <md-input-container fxFlex="30%" *ngIf="changingPassword">
-        <input mdInput formControlName="password" placeholder="New Password"/>
-        <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
-      </md-input-container>
-    </div>
-  </div>
-</form>
+</div>

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.ts
@@ -119,13 +119,13 @@ export class AdminInstructorsFormComponent implements OnInit {
     this.getStates();
   }
 
-  changingPasswordValidators(c: AbstractControl): ValidationErrors {
+  changingPasswordValidators(control: AbstractControl): ValidationErrors {
     if (this.changingPassword) {
       const validators = Validators.compose([
         Validators.required,
         Validators.pattern(AppConstants.OLValidators.Password)
       ]);
-      return validators(c);
+      return validators(control);
     } else {
       return null;
     }

--- a/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-instructors-form/admin-instructors-form.component.ts
@@ -1,15 +1,14 @@
-import {Component, Input, OnInit} from "@angular/core";
+import {Component, EventEmitter, Input, OnInit, Output} from "@angular/core";
 import {FormBuilder, FormGroup, Validators} from "@angular/forms";
-import {MdDialogRef} from "@angular/material";
 import {Observable} from "rxjs/Observable";
 import * as _ from "lodash";
 
-import {AdminDialogComponent} from "../../admin-dialog.component";
 import {AppConstants} from "../../../../app.constants";
 import {AdminTabs} from "../../admin.constants";
 import {NotifyService} from "../../../../services/notify.service";
 import {AdminService} from "../../../../services/admin.service";
 import {Principal} from "../../../../shared/auth/principal-storage.service";
+import {Account} from "../../../../models/account.model";
 
 @Component({
   selector: 'admin-instructors-form',
@@ -21,6 +20,13 @@ export class AdminInstructorsFormComponent implements OnInit {
   @Input('item') formInstructor: any;
   @Input() adding: boolean;
   @Input('organizations') organizations: any[];
+  @Input('parent') instructorForm: FormGroup;
+
+  @Output() onAdd = new EventEmitter<Account>();
+  @Output() onUpdate = new EventEmitter<Account>();
+  @Output() onDelete = new EventEmitter();
+  @Output() onEdit = new EventEmitter<boolean>();
+
   editing: boolean;
   changingPassword: boolean;
   isInstructor: boolean;
@@ -30,7 +36,6 @@ export class AdminInstructorsFormComponent implements OnInit {
 
   filteredStates: Observable<any[]>;
 
-  instructorForm: FormGroup;
   formErrors = {
     firstName: '',
     lastName: '',
@@ -99,8 +104,7 @@ export class AdminInstructorsFormComponent implements OnInit {
     }
   };
 
-  constructor(public dialogRef: MdDialogRef<AdminDialogComponent>,
-              private fb: FormBuilder,
+  constructor(private fb: FormBuilder,
               private notify: NotifyService,
               private adminService: AdminService,
               private principal: Principal) {}
@@ -115,7 +119,7 @@ export class AdminInstructorsFormComponent implements OnInit {
   }
 
   private buildForm(): void {
-    this.instructorForm = this.fb.group({
+    const childForm = this.fb.group({
       firstName: [this.formInstructor.firstName, [
         Validators.required,
         Validators.maxLength(50)
@@ -169,6 +173,10 @@ export class AdminInstructorsFormComponent implements OnInit {
         Validators.required
       ]]
     });
+    for (let key in childForm.controls) {
+      this.instructorForm.addControl(key, childForm.get(key));
+    }
+
     this.instructorForm.valueChanges.subscribe(data => this.onValueChanged());
     this.onValueChanged();
   }
@@ -203,9 +211,11 @@ export class AdminInstructorsFormComponent implements OnInit {
       if (editing) {
         this.instructorForm.enable();
         this.editing = true;
+        this.onEdit.emit(true);
       } else {
         this.instructorForm.disable();
         this.editing = false;
+        this.onEdit.emit(false);
       }
     }
   }
@@ -235,16 +245,19 @@ export class AdminInstructorsFormComponent implements OnInit {
       }
     } else {
       this.instructorForm.markAsTouched();
+      for (let key in this.instructorForm.controls) {
+        // TODO: MD - Try to take this out at some point
+        // TODO: MD - The child form doesn't show up at submitted, so the validation errors won't show
+        this.instructorForm.controls[key].markAsTouched();
+      }
       this.updateFormErrors(this.instructorForm, this.formErrors, this.validationMessages);
     }
   }
 
   private add(): void {
     this.adminService.create(AdminTabs.Instructor.route, this.instructorForm.value).subscribe(resp => {
-      this.dialogRef.close({
-        type: 'ADD',
-        data: resp
-      });
+      this.onAdd.emit(resp);
+      this.setEditing(false);
       this.notify.success('Successfully added instructor');
     }, error => {
       this.notify.error('Failed to add instructor');
@@ -254,10 +267,8 @@ export class AdminInstructorsFormComponent implements OnInit {
   private update(): void {
     const toUpdate = this.prepareToUpdate();
     this.adminService.update(AdminTabs.Instructor.route, toUpdate).subscribe(resp => {
-      this.dialogRef.close({
-        type: 'UPDATE',
-        data: resp
-      });
+      this.onUpdate.emit(resp);
+      this.setEditing(false);
       this.notify.success('Successfully updated instructor');
     }, error => {
       this.notify.error('Failed to update instructor');
@@ -287,12 +298,7 @@ export class AdminInstructorsFormComponent implements OnInit {
 
   delete(): void {
     this.adminService.delete(AdminTabs.Instructor.route, this.formInstructor.id).subscribe(resp => {
-      this.dialogRef.close({
-        type: 'DELETE',
-        data: {
-          id: this.formInstructor.id
-        }
-      });
+      this.onDelete.emit();
       this.notify.success('Successfully deleted instructor');
     }, error => {
       this.notify.error('Failed to delete instructor');
@@ -308,7 +314,8 @@ export class AdminInstructorsFormComponent implements OnInit {
   }
 
   close(): void {
-    this.dialogRef.close();
+    this.ngOnInit();
+    this.onEdit.emit(false);
   }
 
   resetPassword(changingPassword: boolean): void {

--- a/www/src/app/controls/admin/admin-forms/admin-org-administrators-dialog/admin-org-administrators-dialog.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-org-administrators-dialog/admin-org-administrators-dialog.component.html
@@ -1,19 +1,19 @@
-<form [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
+<form [formGroup]="orgAdministratorForm" (ngSubmit)="orgAdminForm.save()" novalidate>
   <div class="ol-dialog-header" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
     <div fxLayout="row" fxLayoutAlign="start center">
       <div><button md-button type="reset" (click)="close()"><i class="fa fa-times fa-lg"></i></button></div>
-      <span class="ol-dialog-title" *ngIf="!editing">Administrator Details</span>
-      <span class="ol-dialog-title edit" *ngIf="adding">New Administrator</span>
-      <span class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Administrator</span>
+      <span class="ol-dialog-title" *ngIf="!editing">Org Administrator Details</span>
+      <span class="ol-dialog-title edit" *ngIf="adding">New Org Administrator</span>
+      <span class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Org Administrator</span>
     </div>
     <div fxLayout="row">
       <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
         <md-icon>save</md-icon>
       </button>
-      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="orgAdminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
         <md-icon>clear</md-icon>
       </button>
-      <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+      <button md-raised-button type="button" *ngIf="!editing" (click)="orgAdminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
         <md-icon>create</md-icon>
       </button>
       <button md-raised-button type="button" *ngIf="!editing" [mdMenuTriggerFor]="deleteMenu" class="ol-dialog-button pink-button" mdTooltip="Delete">
@@ -21,12 +21,12 @@
       </button>
       <md-menu #deleteMenu="mdMenu">
         <button md-menu-item type="button" disabled class="pink-button">Are you sure?</button>
-        <button md-menu-item type="button" (click)="adminForm.delete()">Yes, delete it</button>
+        <button md-menu-item type="button" (click)="orgAdminForm.delete()">Yes, delete it</button>
         <button md-menu-item type="button">No, go back</button>
       </md-menu>
     </div>
   </div>
-  <admin-administrators-form #adminForm [parent]="administratorForm" [item]="formAdministrator" [adding]="adding" [organizations]="organizations"
+  <admin-org-administrators-form #orgAdminForm [parent]="orgAdministratorForm" [item]="formOrgAdministrator" [adding]="adding" [organizations]="organizations"
                              (onAdd)="added($event)" (onUpdate)="updated($event)" (onDelete)="deleted()" (onEdit)="updateEditing($event)">
-  </admin-administrators-form>
+  </admin-org-administrators-form>
 </form>

--- a/www/src/app/controls/admin/admin-forms/admin-org-administrators-dialog/admin-org-administrators-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-org-administrators-dialog/admin-org-administrators-dialog.component.ts
@@ -1,26 +1,25 @@
 import {Component, Input, OnInit} from "@angular/core";
+import {FormGroup} from "@angular/forms";
 import {MdDialogRef} from "@angular/material";
 
 import {AdminDialogComponent} from "../../admin-dialog.component";
-import {Admin} from "../../../../models/admin.model";
-import {FormGroup} from "@angular/forms";
 
 @Component({
-  selector: 'admin-administrators-dialog',
-  templateUrl: './admin-administrators-dialog.component.html',
+  selector: 'admin-org-administrators-dialog',
+  templateUrl: './admin-org-administrators-dialog.component.html',
   styleUrls: ['../../../dialog-forms.css']
 })
-export class AdminAdministratorsDialogComponent implements OnInit {
+export class AdminOrgAdministratorsDialogComponent implements OnInit {
 
-  @Input('item') formAdministrator: Admin;
+  @Input('item') formOrgAdministrator: any;
   @Input() adding: boolean;
   @Input('organizations') organizations: any[];
 
-  editing: boolean = false;
-  administratorForm: FormGroup;
+  editing: boolean;
+  orgAdministratorForm: FormGroup;
 
   constructor(public dialogRef: MdDialogRef<AdminDialogComponent>) {
-    this.administratorForm = new FormGroup({});
+    this.orgAdministratorForm = new FormGroup({});
   }
 
   ngOnInit(): void {
@@ -50,7 +49,7 @@ export class AdminAdministratorsDialogComponent implements OnInit {
     this.dialogRef.close({
       type: 'DELETE',
       data: {
-        id: this.formAdministrator.id
+        id: this.formOrgAdministrator.id
       }
     });
   }

--- a/www/src/app/controls/admin/admin-forms/admin-org-administrators-dialog/admin-org-administrators-dialog.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-org-administrators-dialog/admin-org-administrators-dialog.component.ts
@@ -26,7 +26,6 @@ export class AdminOrgAdministratorsDialogComponent implements OnInit {
     this.editing = this.adding;
   }
 
-  // TODO: Convert this to a 'status' of EDITING, ADDING, VIEWING, etc
   updateEditing(isEditing: boolean): void {
     this.editing = isEditing;
   };

--- a/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.html
@@ -1,100 +1,71 @@
-<form [formGroup]="orgAdministratorForm" (ngSubmit)="save()" novalidate>
-  <div class="ol-dialog-header" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
-    <div fxLayout="row" fxLayoutAlign="start center">
-      <div><button md-button type="reset" (click)="close()"><i class="fa fa-times fa-lg"></i></button></div>
-      <span class="ol-dialog-title" *ngIf="!editing">Org Administrator Details</span>
-      <span class="ol-dialog-title edit" *ngIf="adding">New Org Administrator</span>
-      <span class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Org Administrator</span>
+<div [formGroup]="orgAdministratorForm" class="ol-dialog-content">
+  <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutWrap>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="firstName" placeholder="First Name*"/>
+      <md-error *ngIf="formErrors.firstName">{{formErrors.firstName}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="lastName" placeholder="Last Name*"/>
+      <md-error *ngIf="formErrors.lastName">{{formErrors.lastName}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="login" placeholder="Username*"/>
+      <md-error *ngIf="formErrors.login">{{formErrors.login}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%" *ngIf="adding">
+      <input mdInput formControlName="password" placeholder="Password*"/>
+      <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <textarea mdInput formControlName="notes" placeholder="Notes"></textarea>
+      <md-error *ngIf="formErrors.notes">{{formErrors.notes}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="email" placeholder="Email"/>
+      <md-error *ngIf="formErrors.email">{{formErrors.email}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="streetAddress1" placeholder="Address 1"/>
+      <md-error *ngIf="formErrors.streetAddress1">{{formErrors.streetAddress1}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="30%">
+      <input mdInput formControlName="streetAddress2" placeholder="Address 2"/>
+      <md-error *ngIf="formErrors.streetAddress2">{{formErrors.streetAddress2}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="city" placeholder="City"/>
+      <md-error *ngIf="formErrors.city">{{formErrors.city}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="state" placeholder="State" [mdAutocomplete]="state"/>
+      <md-autocomplete #state="mdAutocomplete" [displayWith]="displayState">
+        <md-option *ngFor="let state of filteredStates | async" [value]="state.value">{{state.name}}</md-option>
+      </md-autocomplete>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="phoneNumber" placeholder="Phone"/>
+      <md-error *ngIf="formErrors.phoneNumber">{{formErrors.phoneNumber}}</md-error>
+    </md-input-container>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="postalCode" placeholder="Postal Code"/>
+      <md-error *ngIf="formErrors.postalCode">{{formErrors.postalCode}}</md-error>
+    </md-input-container>
+    <div fxLayout="column" fxFlex="20%">
+      <md-error *ngIf="formErrors.organizationId">{{formErrors.organizationId}}</md-error>
+      <md-select formControlName="organizationId" placeholder="Organization*" [disabled]="!editing">
+        <md-option *ngFor="let organization of organizations" [(value)]="organization.id">{{organization.name}}</md-option>
+      </md-select>
     </div>
-    <div fxLayout="row">
-      <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
-        <md-icon>save</md-icon>
-      </button>
-      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
-        <md-icon>clear</md-icon>
-      </button>
-      <button md-raised-button type="button" *ngIf="!editing" (click)="edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
-        <md-icon>create</md-icon>
-      </button>
-      <button md-raised-button type="button" *ngIf="!editing" [mdMenuTriggerFor]="deleteMenu" class="ol-dialog-button pink-button" mdTooltip="Delete">
-        <md-icon>delete</md-icon>
-      </button>
-      <md-menu #deleteMenu="mdMenu">
-        <button md-menu-item type="button" disabled class="pink-button">Are you sure?</button>
-        <button md-menu-item type="button" (click)="delete()">Yes, delete it</button>
-        <button md-menu-item type="button">No, go back</button>
-      </md-menu>
+    <md-input-container fxFlex="20%">
+      <input mdInput formControlName="orgRole" placeholder="Org Role*"/>
+      <md-error *ngIf="formErrors.orgRole">{{formErrors.orgRole}}</md-error>
+    </md-input-container>
+    <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
+      <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
     </div>
+    <md-input-container fxFlex="30%" *ngIf="changingPassword">
+      <input mdInput formControlName="password" placeholder="New Password"/>
+      <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
+    </md-input-container>
   </div>
-  <div class="ol-dialog-content">
-    <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutWrap>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="firstName" placeholder="First Name*"/>
-        <md-error *ngIf="formErrors.firstName">{{formErrors.firstName}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="lastName" placeholder="Last Name*"/>
-        <md-error *ngIf="formErrors.lastName">{{formErrors.lastName}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="login" placeholder="Username*"/>
-        <md-error *ngIf="formErrors.login">{{formErrors.login}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%" *ngIf="adding">
-        <input mdInput formControlName="password" placeholder="Password*"/>
-        <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <textarea mdInput formControlName="notes" placeholder="Notes"></textarea>
-        <md-error *ngIf="formErrors.notes">{{formErrors.notes}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="email" placeholder="Email"/>
-        <md-error *ngIf="formErrors.email">{{formErrors.email}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="streetAddress1" placeholder="Address 1"/>
-        <md-error *ngIf="formErrors.streetAddress1">{{formErrors.streetAddress1}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="30%">
-        <input mdInput formControlName="streetAddress2" placeholder="Address 2"/>
-        <md-error *ngIf="formErrors.streetAddress2">{{formErrors.streetAddress2}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="city" placeholder="City"/>
-        <md-error *ngIf="formErrors.city">{{formErrors.city}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="state" placeholder="State" [mdAutocomplete]="state"/>
-        <md-autocomplete #state="mdAutocomplete" [displayWith]="displayState">
-          <md-option *ngFor="let state of filteredStates | async" [value]="state.value">{{state.name}}</md-option>
-        </md-autocomplete>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="phoneNumber" placeholder="Phone"/>
-        <md-error *ngIf="formErrors.phoneNumber">{{formErrors.phoneNumber}}</md-error>
-      </md-input-container>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="postalCode" placeholder="Postal Code"/>
-        <md-error *ngIf="formErrors.postalCode">{{formErrors.postalCode}}</md-error>
-      </md-input-container>
-      <div fxLayout="column" fxFlex="20%">
-        <md-error *ngIf="formErrors.organizationId">{{formErrors.organizationId}}</md-error>
-        <md-select formControlName="organizationId" placeholder="Organization*" [disabled]="!editing">
-          <md-option *ngFor="let organization of organizations" [(value)]="organization.id">{{organization.name}}</md-option>
-        </md-select>
-      </div>
-      <md-input-container fxFlex="20%">
-        <input mdInput formControlName="orgRole" placeholder="Org Role*"/>
-        <md-error *ngIf="formErrors.orgRole">{{formErrors.orgRole}}</md-error>
-      </md-input-container>
-      <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
-        <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
-      </div>
-      <md-input-container fxFlex="30%" *ngIf="changingPassword">
-        <input mdInput formControlName="password" placeholder="New Password"/>
-        <md-error *ngIf="formErrors.password">{{formErrors.password}}</md-error>
-      </md-input-container>
-    </div>
-  </div>
-</form>
+</div>

--- a/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.html
+++ b/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.html
@@ -61,7 +61,7 @@
       <md-error *ngIf="formErrors.orgRole">{{formErrors.orgRole}}</md-error>
     </md-input-container>
     <div fxFlex="30%" *ngIf="!adding && editing && !changingPassword">
-      <button md-raised-button (click)="resetPassword(true)" class="reset-password">Change Password</button>
+      <button md-raised-button type="button" (click)="resetPassword(true)" class="reset-password">Change Password</button>
     </div>
     <md-input-container fxFlex="30%" *ngIf="changingPassword">
       <input mdInput formControlName="password" placeholder="New Password"/>

--- a/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.ts
@@ -115,13 +115,13 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
     this.getStates();
   }
 
-  changingPasswordValidators(c: AbstractControl): ValidationErrors {
+  changingPasswordValidators(control: AbstractControl): ValidationErrors {
     if (this.changingPassword) {
       const validators = Validators.compose([
         Validators.required,
         Validators.pattern(AppConstants.OLValidators.Password)
       ]);
-      return validators(c);
+      return validators(control);
     } else {
       return null;
     }

--- a/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.ts
+++ b/www/src/app/controls/admin/admin-forms/admin-org-administrators-form/admin-org-administrators-form.component.ts
@@ -1,15 +1,13 @@
-import {Component, Input, OnInit} from "@angular/core";
+import {Component, EventEmitter, Input, OnInit, Output} from "@angular/core";
 import {FormBuilder, FormGroup, Validators} from "@angular/forms";
-import {MdDialogRef} from "@angular/material";
 import {Observable} from "rxjs/Observable";
 import * as _ from "lodash";
 
-import {AdminDialogComponent} from "../../admin-dialog.component";
 import {AdminService} from "../../../../services/admin.service";
 import {AppConstants} from "../../../../app.constants";
 import {NotifyService} from "../../../../services/notify.service";
-import {OrgAdmin} from "../../../../models/org-admin.model";
 import {AdminTabs} from "../../admin.constants";
+import {Account} from "../../../../models/account.model";
 
 @Component({
   selector: 'admin-org-administrators-form',
@@ -21,6 +19,13 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
   @Input('item') formOrgAdministrator: any;
   @Input() adding: boolean;
   @Input('organizations') organizations: any[];
+  @Input('parent') orgAdministratorForm: FormGroup;
+
+  @Output() onAdd = new EventEmitter<Account>();
+  @Output() onUpdate = new EventEmitter<Account>();
+  @Output() onDelete = new EventEmitter();
+  @Output() onEdit = new EventEmitter<boolean>();
+
   editing: boolean;
   changingPassword: boolean;
 
@@ -29,7 +34,6 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
 
   filteredStates: Observable<any[]>;
 
-  orgAdministratorForm: FormGroup;
   formErrors = {
     firstName: '',
     lastName: '',
@@ -98,8 +102,7 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
     }
   };
 
-  constructor(public dialogRef: MdDialogRef<AdminDialogComponent>,
-              private fb: FormBuilder,
+  constructor(private fb: FormBuilder,
               private notify: NotifyService,
               private adminService: AdminService) {}
 
@@ -112,7 +115,7 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
   }
 
   private buildForm(): void {
-    this.orgAdministratorForm = this.fb.group({
+    const childForm = this.fb.group({
       firstName: [this.formOrgAdministrator.firstName, [
         Validators.required,
         Validators.maxLength(50)
@@ -166,6 +169,10 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
         Validators.required
       ]]
     });
+    for (let key in childForm.controls) {
+      this.orgAdministratorForm.addControl(key, childForm.get(key));
+    }
+
     this.orgAdministratorForm.valueChanges.subscribe(data => this.onValueChanged());
     this.onValueChanged();
   }
@@ -200,9 +207,11 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
       if (editing) {
         this.orgAdministratorForm.enable();
         this.editing = true;
+        this.onEdit.emit(true);
       } else {
         this.orgAdministratorForm.disable();
         this.editing = false;
+        this.onEdit.emit(false);
       }
     }
   }
@@ -232,15 +241,18 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
       }
     } else {
       this.orgAdministratorForm.markAsTouched();
+      for (let key in this.orgAdministratorForm.controls) {
+        // TODO: MD - Try to take this out at some point
+        // TODO: MD - The child form doesn't show up at submitted, so the validation errors won't show
+        this.orgAdministratorForm.controls[key].markAsTouched();
+      }
     }
   }
 
   private add(): void {
     this.adminService.create(AdminTabs.OrgAdministrator.route, this.orgAdministratorForm.value).subscribe(resp => {
-      this.dialogRef.close({
-        type: 'ADD',
-        data: resp
-      });
+      this.onAdd.emit(resp);
+      this.setEditing(false);
       this.notify.success('Successfully added org administrator');
     }, error => {
       this.notify.error('Failed to add org administrator');
@@ -250,10 +262,8 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
   private update(): void {
     const toUpdate = this.prepareToUpdate();
     this.adminService.update(AdminTabs.OrgAdministrator.route, toUpdate).subscribe(resp => {
-      this.dialogRef.close({
-        type: 'UPDATE',
-        data: resp
-      });
+      this.onUpdate.emit(resp);
+      this.setEditing(false);
       this.notify.success('Successfully updated org administrator');
     }, error => {
       this.notify.error('Failed to update org administrator');
@@ -283,12 +293,7 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
 
   delete(): void {
     this.adminService.delete(AdminTabs.OrgAdministrator.route, this.formOrgAdministrator.id).subscribe(resp => {
-      this.dialogRef.close({
-        type: 'DELETE',
-        data: {
-          id: this.formOrgAdministrator.id
-        }
-      });
+      this.onDelete.emit();
       this.notify.success('Successfully deleted org administrator');
     }, error => {
       this.notify.error('Failed to delete org administrator');
@@ -301,10 +306,7 @@ export class AdminOrgAdministratorsFormComponent implements OnInit {
 
   cancel(): void {
     this.ngOnInit();
-  }
-
-  close(): void {
-    this.dialogRef.close();
+    this.onEdit.emit(false);
   }
 
   resetPassword(changingPassword: boolean): void {

--- a/www/src/app/controls/admin/admin.module.ts
+++ b/www/src/app/controls/admin/admin.module.ts
@@ -14,6 +14,7 @@ import {AdminProgramsComponent} from "./admin-tabs/admin-programs.component";
 import {AdminSessionsComponent} from "./admin-tabs/admin-sessions.component";
 import {AdminStudentsComponent} from "./admin-tabs/admin-students.component";
 import {OLAdminFormsModule} from "./admin-forms/admin-forms.module";
+import {AdminAdministratorsFormComponent} from "./admin-forms/admin-administrators-form/admin-administrators-form.component";
 
 @NgModule({
   declarations: [
@@ -35,6 +36,9 @@ import {OLAdminFormsModule} from "./admin-forms/admin-forms.module";
     MdIconModule,
     MdTooltipModule,
     OLAdminFormsModule
+  ],
+  exports: [
+    AdminAdministratorsFormComponent
   ],
   entryComponents: [
     AdminDialogComponent

--- a/www/src/app/controls/admin/admin.module.ts
+++ b/www/src/app/controls/admin/admin.module.ts
@@ -15,6 +15,8 @@ import {AdminSessionsComponent} from "./admin-tabs/admin-sessions.component";
 import {AdminStudentsComponent} from "./admin-tabs/admin-students.component";
 import {OLAdminFormsModule} from "./admin-forms/admin-forms.module";
 import {AdminAdministratorsFormComponent} from "./admin-forms/admin-administrators-form/admin-administrators-form.component";
+import {AdminOrgAdministratorsFormComponent} from "./admin-forms/admin-org-administrators-form/admin-org-administrators-form.component";
+import {AdminInstructorsFormComponent} from "./admin-forms/admin-instructors-form/admin-instructors-form.component";
 
 @NgModule({
   declarations: [
@@ -38,7 +40,9 @@ import {AdminAdministratorsFormComponent} from "./admin-forms/admin-administrato
     OLAdminFormsModule
   ],
   exports: [
-    AdminAdministratorsFormComponent
+    AdminAdministratorsFormComponent,
+    AdminOrgAdministratorsFormComponent,
+    AdminInstructorsFormComponent,
   ],
   entryComponents: [
     AdminDialogComponent

--- a/www/src/app/pages/profile-page/profile-page.component.css
+++ b/www/src/app/pages/profile-page/profile-page.component.css
@@ -1,3 +1,10 @@
 .profile-form {
-  padding: 10px 20px;
+  padding: 20px 40px;
+}
+.profile-form-sub{
+  padding: 0px 50px;
+}
+
+.padding-top{
+  padding-top: 20px;
 }

--- a/www/src/app/pages/profile-page/profile-page.component.html
+++ b/www/src/app/pages/profile-page/profile-page.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="item" [ngSwitch]="route">
 
-  <form *ngSwitchCase="'administrators'" [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
+  <form *ngSwitchCase="'administrators'" [formGroup]="profileForm" (ngSubmit)="adminForm.save()" novalidate>
     <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
       <div fxLayout="row" fxLayoutAlign="start center">
         <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
@@ -18,12 +18,12 @@
         </button>
       </div>
     </div>
-    <admin-administrators-form #adminForm [parent]="administratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+    <admin-administrators-form #adminForm [parent]="profileForm" [item]="item" [adding]="adding" [organizations]="organizations"
                                (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
     </admin-administrators-form>
   </form>
 
-  <form *ngSwitchCase="'org-administrators'" [formGroup]="orgAdministratorForm" (ngSubmit)="orgAdminForm.save()" novalidate>
+  <form *ngSwitchCase="'org-administrators'" [formGroup]="profileForm" (ngSubmit)="orgAdminForm.save()" novalidate>
     <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
       <div fxLayout="row" fxLayoutAlign="start center">
         <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
@@ -41,12 +41,12 @@
         </button>
       </div>
     </div>
-    <admin-org-administrators-form #orgAdminForm [parent]="orgAdministratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+    <admin-org-administrators-form #orgAdminForm [parent]="profileForm" [item]="item" [adding]="adding" [organizations]="organizations"
                                (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
     </admin-org-administrators-form>
   </form>
 
-  <form *ngSwitchCase="'instructors'" [formGroup]="instructorForm" (ngSubmit)="instructForm.save()" novalidate>
+  <form *ngSwitchCase="'instructors'" [formGroup]="profileForm" (ngSubmit)="instructorForm.save()" novalidate>
     <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
       <div fxLayout="row" fxLayoutAlign="start center">
         <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
@@ -56,15 +56,15 @@
         <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
           <md-icon>save</md-icon>
         </button>
-        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="instructForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="instructorForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
           <md-icon>clear</md-icon>
         </button>
-        <button md-raised-button type="button" *ngIf="!editing" (click)="instructForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+        <button md-raised-button type="button" *ngIf="!editing" (click)="instructorForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
           <md-icon>create</md-icon>
         </button>
       </div>
     </div>
-    <admin-instructors-form #instructForm [parent]="instructorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+    <admin-instructors-form #instructorForm [parent]="profileForm" [item]="item" [adding]="adding" [organizations]="organizations"
                             (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
     </admin-instructors-form>
   </form>

--- a/www/src/app/pages/profile-page/profile-page.component.html
+++ b/www/src/app/pages/profile-page/profile-page.component.html
@@ -1,31 +1,22 @@
-<div fxLayout="row" fxLayoutAlign="center">
-  <form #profileForm="ngForm" class="profile-form" fxLayout="column" fxFlex.gt-sm="960px">
-    <div fxLayout="row" fxLayoutAlign="space-between center">
-      <h2>Profile Details</h2>
-      <div fxLayout="row">
-        <button md-raised-button *ngIf="editing" (click)="save()" class="ol-dialog-button grey-button" mdTooltip="Save">
-          <md-icon>save</md-icon>
-        </button>
-        <button md-raised-button *ngIf="editing" (click)="cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
-          <md-icon>clear</md-icon>
-        </button>
-        <button md-raised-button *ngIf="!editing" (click)="edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
-          <md-icon>create</md-icon>
-        </button>
-      </div>
+<form [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
+  <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
+    <div fxLayout="row" fxLayoutAlign="start center">
+      <h2 class="ol-dialog-title" *ngIf="!editing">Administrator Details</h2>
+      <h2 class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Administrator</h2>
     </div>
-    <div fxLayout="column" fxLayoutAlign="start stretch">
-      <div fxLayout="row" fxLayoutAlign="space-between">
-        <md-input-container fxFlex="47%">
-          <input mdInput [disabled]="!editing" name="firstName" [(ngModel)]="profile.firstName" placeholder="First Name"/>
-        </md-input-container>
-        <md-input-container fxFlex="47%">
-          <input mdInput [disabled]="!editing" name="lastName" [(ngModel)]="profile.lastName" placeholder="Last Name"/>
-        </md-input-container>
-      </div>
-      <md-input-container>
-        <textarea mdInput [disabled]="!editing || !ageAllowed()" name="biography" [(ngModel)]="profile.biography" placeholder="Bio"></textarea>
-      </md-input-container>
+    <div fxLayout="row">
+      <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
+        <md-icon>save</md-icon>
+      </button>
+      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+        <md-icon>clear</md-icon>
+      </button>
+      <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+        <md-icon>create</md-icon>
+      </button>
     </div>
-  </form>
-</div>
+  </div>
+  <admin-administrators-form #adminForm [fg]="administratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+                             (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
+  </admin-administrators-form>
+</form>

--- a/www/src/app/pages/profile-page/profile-page.component.html
+++ b/www/src/app/pages/profile-page/profile-page.component.html
@@ -1,8 +1,6 @@
-<div *ngIf="item" [ngSwitch]="route"> <!--TODO: MD - Cleanup-->
+<div *ngIf="item" [ngSwitch]="route">
 
   <form *ngSwitchCase="'administrators'" [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
-    <p>{{route}}</p>
-    <p>administrators</p>
     <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
       <div fxLayout="row" fxLayoutAlign="start center">
         <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
@@ -25,9 +23,7 @@
     </admin-administrators-form>
   </form>
 
-  <form *ngSwitchCase="'org-administrators'" [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
-    <p>{{route}}</p>
-    <p>org-administrators</p>
+  <form *ngSwitchCase="'org-administrators'" [formGroup]="orgAdministratorForm" (ngSubmit)="orgAdminForm.save()" novalidate>
     <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
       <div fxLayout="row" fxLayoutAlign="start center">
         <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
@@ -37,22 +33,20 @@
         <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
           <md-icon>save</md-icon>
         </button>
-        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="orgAdminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
           <md-icon>clear</md-icon>
         </button>
-        <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+        <button md-raised-button type="button" *ngIf="!editing" (click)="orgAdminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
           <md-icon>create</md-icon>
         </button>
       </div>
     </div>
-    <admin-org-administrators-form #adminForm [parent]="administratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+    <admin-org-administrators-form #orgAdminForm [parent]="orgAdministratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
                                (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
     </admin-org-administrators-form>
   </form>
 
-  <form *ngSwitchCase="'instructors'" [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
-    <p>{{route}}</p>
-    <p>instructors</p>
+  <form *ngSwitchCase="'instructors'" [formGroup]="instructorForm" (ngSubmit)="instructForm.save()" novalidate>
     <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
       <div fxLayout="row" fxLayoutAlign="start center">
         <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
@@ -62,16 +56,16 @@
         <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
           <md-icon>save</md-icon>
         </button>
-        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="instructForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
           <md-icon>clear</md-icon>
         </button>
-        <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+        <button md-raised-button type="button" *ngIf="!editing" (click)="instructForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
           <md-icon>create</md-icon>
         </button>
       </div>
     </div>
-    <admin-instructors-form #adminForm [parent]="administratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
-                               (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
+    <admin-instructors-form #instructForm [parent]="instructorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+                            (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
     </admin-instructors-form>
   </form>
 

--- a/www/src/app/pages/profile-page/profile-page.component.html
+++ b/www/src/app/pages/profile-page/profile-page.component.html
@@ -1,22 +1,78 @@
-<form [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
-  <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
-    <div fxLayout="row" fxLayoutAlign="start center">
-      <h2 class="ol-dialog-title" *ngIf="!editing">Administrator Details</h2>
-      <h2 class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Administrator</h2>
+<div *ngIf="item" [ngSwitch]="route"> <!--TODO: MD - Cleanup-->
+
+  <form *ngSwitchCase="'administrators'" [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
+    <p>{{route}}</p>
+    <p>administrators</p>
+    <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
+      <div fxLayout="row" fxLayoutAlign="start center">
+        <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
+        <h2 class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Profile</h2>
+      </div>
+      <div fxLayout="row">
+        <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
+          <md-icon>save</md-icon>
+        </button>
+        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+          <md-icon>clear</md-icon>
+        </button>
+        <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+          <md-icon>create</md-icon>
+        </button>
+      </div>
     </div>
-    <div fxLayout="row">
-      <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
-        <md-icon>save</md-icon>
-      </button>
-      <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
-        <md-icon>clear</md-icon>
-      </button>
-      <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
-        <md-icon>create</md-icon>
-      </button>
+    <admin-administrators-form #adminForm [parent]="administratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+                               (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
+    </admin-administrators-form>
+  </form>
+
+  <form *ngSwitchCase="'org-administrators'" [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
+    <p>{{route}}</p>
+    <p>org-administrators</p>
+    <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
+      <div fxLayout="row" fxLayoutAlign="start center">
+        <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
+        <h2 class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Profile</h2>
+      </div>
+      <div fxLayout="row">
+        <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
+          <md-icon>save</md-icon>
+        </button>
+        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+          <md-icon>clear</md-icon>
+        </button>
+        <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+          <md-icon>create</md-icon>
+        </button>
+      </div>
     </div>
-  </div>
-  <admin-administrators-form #adminForm [fg]="administratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
-                             (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
-  </admin-administrators-form>
-</form>
+    <admin-org-administrators-form #adminForm [parent]="administratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+                               (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
+    </admin-org-administrators-form>
+  </form>
+
+  <form *ngSwitchCase="'instructors'" [formGroup]="administratorForm" (ngSubmit)="adminForm.save()" novalidate>
+    <p>{{route}}</p>
+    <p>instructors</p>
+    <div class="profile-form" [ngClass]="{edit: editing}" fxLayout="row" fxLayoutAlign="space-between center">
+      <div fxLayout="row" fxLayoutAlign="start center">
+        <h2 class="ol-dialog-title" *ngIf="!editing">Profile Details</h2>
+        <h2 class="ol-dialog-title edit" *ngIf="editing && !adding">Edit Profile</h2>
+      </div>
+      <div fxLayout="row">
+        <button md-raised-button type="submit" *ngIf="editing" class="ol-dialog-button grey-button" mdTooltip="Save">
+          <md-icon>save</md-icon>
+        </button>
+        <button md-raised-button type="reset" *ngIf="editing && !adding" (click)="adminForm.cancel()" class="ol-dialog-button navy-button" mdTooltip="Cancel">
+          <md-icon>clear</md-icon>
+        </button>
+        <button md-raised-button type="button" *ngIf="!editing" (click)="adminForm.edit()" class="ol-dialog-button grey-button" mdTooltip="Edit">
+          <md-icon>create</md-icon>
+        </button>
+      </div>
+    </div>
+    <admin-instructors-form #adminForm [parent]="administratorForm" [item]="item" [adding]="adding" [organizations]="organizations"
+                               (onUpdate)="updated($event)" (onEdit)="updateEditing($event)">
+    </admin-instructors-form>
+  </form>
+
+</div>

--- a/www/src/app/pages/profile-page/profile-page.component.ts
+++ b/www/src/app/pages/profile-page/profile-page.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from "@angular/core";
+import {Component, Input, OnInit} from "@angular/core";
 import {UserService} from "../../services/user.service";
 import {AccountService} from "../../shared/auth/account.service";
 import {Principal} from "../../shared/auth/principal-storage.service";
@@ -6,36 +6,55 @@ import {Account} from "../../models/account.model";
 import {AdminService} from "../../services/admin.service";
 import {AdminTabs} from "../../controls/admin/admin.constants";
 import {FormGroup} from "@angular/forms";
+import {AppConstants} from "../../app.constants";
 
 @Component({
   selector: 'profile-form',
   templateUrl: './profile-page.component.html',
   styleUrls: ['./profile-page.component.css']
 })
-export class ProfilePageComponent {
-
-  @Input() profile: any = {};
+export class ProfilePageComponent implements OnInit {
 
   item: Account;
   organizations: any[];
   administratorForm: FormGroup;
   editing: boolean = false;
 
+  route: string;
+
   constructor(private userService: UserService,
               private accountService: AccountService,
               private adminService: AdminService,
               private principal: Principal) {
 
-    this.item = this.principal.getUserIdentity();
-    this.adminService.getAll(AdminTabs.Organization.route);
-    this.accountService.get().subscribe(resp => {this.profile = resp});
     this.administratorForm = new FormGroup({});
   }
 
+  ngOnInit(): void {
+    switch (this.principal.getRole()) {
+      case AppConstants.Role.Admin.name:
+        this.route = AdminTabs.Administrator.route;
+        break;
+      case AppConstants.Role.OrgAdmin.name:
+        this.route = AdminTabs.OrgAdministrator.route;
+        break;
+      case AppConstants.Role.Instructor.name:
+        this.route = AdminTabs.Instructor.route;
+        break;
+    }
+
+    this.adminService.get(this.route, this.principal.getId()).subscribe(resp => {
+      this.item = resp;
+    });
+  }
 
   // TODO: Convert this to a 'status' of EDITING, ADDING, VIEWING, etc
   updateEditing(isEditing: boolean): void {
     this.editing = isEditing;
   };
+
+  updated(): void {
+    this.editing = false;
+  }
 
 }

--- a/www/src/app/pages/profile-page/profile-page.component.ts
+++ b/www/src/app/pages/profile-page/profile-page.component.ts
@@ -17,7 +17,7 @@ export class ProfilePageComponent implements OnInit {
 
   item: Account;
   organizations: any[];
-  administratorForm: FormGroup;
+  profileForm: FormGroup;
   editing: boolean = false;
 
   route: string;
@@ -27,7 +27,7 @@ export class ProfilePageComponent implements OnInit {
               private adminService: AdminService,
               private principal: Principal) {
 
-    this.administratorForm = new FormGroup({});
+    this.profileForm = new FormGroup({});
   }
 
   ngOnInit(): void {

--- a/www/src/app/pages/profile-page/profile-page.component.ts
+++ b/www/src/app/pages/profile-page/profile-page.component.ts
@@ -2,43 +2,40 @@ import {Component, Input} from "@angular/core";
 import {UserService} from "../../services/user.service";
 import {AccountService} from "../../shared/auth/account.service";
 import {Principal} from "../../shared/auth/principal-storage.service";
+import {Account} from "../../models/account.model";
+import {AdminService} from "../../services/admin.service";
+import {AdminTabs} from "../../controls/admin/admin.constants";
+import {FormGroup} from "@angular/forms";
 
 @Component({
   selector: 'profile-form',
   templateUrl: './profile-page.component.html',
-  styleUrls: ['./profile-page.component.css', '../../controls/dialog-forms.css']
+  styleUrls: ['./profile-page.component.css']
 })
 export class ProfilePageComponent {
 
   @Input() profile: any = {};
-  @Input() editing: boolean;
 
-  constructor(private userService: UserService, private accountService: AccountService, private principal: Principal) {
+  item: Account;
+  organizations: any[];
+  administratorForm: FormGroup;
+  editing: boolean = false;
+
+  constructor(private userService: UserService,
+              private accountService: AccountService,
+              private adminService: AdminService,
+              private principal: Principal) {
+
+    this.item = this.principal.getUserIdentity();
+    this.adminService.getAll(AdminTabs.Organization.route);
     this.accountService.get().subscribe(resp => {this.profile = resp});
+    this.administratorForm = new FormGroup({});
   }
 
-  edit(): void {
-    this.editing = true;
-  }
 
-  cancel(exit: boolean): void {
-    this.editing = false;
-    this.accountService.get().subscribe(resp => {this.profile = resp});
-  }
-
-  save(): void {
-    this.userService.update(this.profile).subscribe(resp => {
-      this.handleSaveResponse(resp);
-      this.principal.authenticate(resp);
-    });
-  }
-
-  handleSaveResponse(resp): void {
-    this.editing = false;
-  }
-
-  ageAllowed(): boolean {
-    return this.profile['14Plus'];
-  }
+  // TODO: Convert this to a 'status' of EDITING, ADDING, VIEWING, etc
+  updateEditing(isEditing: boolean): void {
+    this.editing = isEditing;
+  };
 
 }

--- a/www/src/app/pages/profile-page/profile-page.component.ts
+++ b/www/src/app/pages/profile-page/profile-page.component.ts
@@ -48,7 +48,6 @@ export class ProfilePageComponent implements OnInit {
     });
   }
 
-  // TODO: Convert this to a 'status' of EDITING, ADDING, VIEWING, etc
   updateEditing(isEditing: boolean): void {
     this.editing = isEditing;
   };


### PR DESCRIPTION
Allow profile edit functionality on the profile page.

- Abstract the admin, org admin, and instructor admin forms away from their default dialogs so that they can be reused.