### PR TITLE
Feature S3 encryption

### DIFF
--- a/services/src/main/java/org/openlearn/client/S3Client.java
+++ b/services/src/main/java/org/openlearn/client/S3Client.java
@@ -1,0 +1,55 @@
+package org.openlearn.client;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.*;
+import com.amazonaws.services.s3.model.*;
+import org.openlearn.config.ApplicationProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+public class S3Client {
+	private static final Logger log = LoggerFactory.getLogger(S3Client.class);
+
+	private AmazonS3 client;
+
+	private boolean requestServerSideEncryption;
+
+	public S3Client(ApplicationProperties properties) {
+		if (properties.getUploadKmsAlias() != null) {
+			// Use custom client-side encryption method
+			this.client = AmazonS3EncryptionClientBuilder
+				.standard()
+				.withCryptoConfiguration(new CryptoConfiguration(CryptoMode.EncryptionOnly))
+				// Can either be Key ID or alias (prefixed with 'alias/')
+				.withEncryptionMaterials(new KMSEncryptionMaterialsProvider(properties.getUploadKmsAlias()))
+				.build();
+			this.requestServerSideEncryption = false;
+		} else {
+			this.client = AmazonS3ClientBuilder.defaultClient();
+			this.requestServerSideEncryption = true;
+		}
+	}
+
+	public void putObject(PutObjectRequest request)  throws AmazonServiceException {
+		if (requestServerSideEncryption) {
+			ObjectMetadata metadata = request.getMetadata();
+			metadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+		}
+
+		this.client.putObject(request);
+	}
+
+	public S3Object getObject(GetObjectRequest request)  throws AmazonServiceException {
+		return this.client.getObject(request);
+	}
+
+	public void deleteObject(DeleteObjectRequest request) throws AmazonServiceException {
+		this.client.deleteObject(request);
+	}
+
+	public void deleteObjects(DeleteObjectsRequest request) throws AmazonServiceException {
+		this.client.deleteObjects(request);
+	}
+}

--- a/services/src/main/java/org/openlearn/config/ApplicationProperties.java
+++ b/services/src/main/java/org/openlearn/config/ApplicationProperties.java
@@ -10,20 +10,28 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "application", ignoreUnknownFields = false)
 public class ApplicationProperties {
 
-    private String uploadBucket;
-
     private final Recaptcha recaptcha = new Recaptcha();
 
+    private final Uploads uploads = new Uploads();
+
     public String getUploadBucket() {
-        return uploadBucket;
+        return this.uploads.s3bucket;
     }
 
     public void setUploadBucket(String uploadBucket) {
-        this.uploadBucket = uploadBucket;
+        this.uploads.setS3bucket(uploadBucket);
     }
 
     public Recaptcha getRecaptcha() {
         return recaptcha;
+    }
+
+    public Uploads getUploads() {
+      return uploads;
+    }
+
+    public String getUploadKmsAlias() {
+      return this.uploads.getKmsAlias();
     }
 
     public static class Recaptcha {
@@ -57,5 +65,32 @@ public class ApplicationProperties {
         public void setVerificationUrl(String verificationUrl) {
             this.verificationUrl = verificationUrl;
         }
+    }
+
+    public static class Uploads {
+      private String s3bucket;
+
+      private String kmsAlias;
+
+      public String getS3bucket() {
+        return s3bucket;
+      }
+
+      public void setS3bucket(String s3bucket) {
+        this.s3bucket = s3bucket;
+      }
+
+      public String getKmsAlias() {
+        return kmsAlias;
+      }
+
+      public void setKmsAlias(String kmsAlias) {
+        this.kmsAlias = kmsAlias;
+      }
+
+      @Override
+      public String toString() {
+        return super.toString() + "s3bucket=" + this.s3bucket + ";kmAlias=" + this.kmsAlias;
+      }
     }
 }

--- a/services/src/main/resources/config/application-custom.example.yml
+++ b/services/src/main/resources/config/application-custom.example.yml
@@ -2,7 +2,7 @@
 # Spring Boot "Custom" configurations for the current profile.
 #
 # NOTE FOR DEVELOPERS:
-# 	You'll want to copy this file to application-custom.yml and fill
+#   You'll want to copy this file to application-custom.yml and fill
 #   in the datasource information and S3 information.
 #
 #   Assuming you're in the project root
@@ -34,7 +34,9 @@ liquibase:
 
 application:
 
-  upload-bucket: dev.openlearn-uploads.credera
+    uploads:
+        s3bucket: example.openlearn-uploads.credera
+        kms-alias: "alias/openlearn"
 
-  recaptcha:
-    site-secret: 6LfmlDwUAAAAAN8uRe-dkXwWPoIk4mFznmj6Cdzt
+    recaptcha:
+        site-secret: 6LfmlDwUAAAAAN8uRe-dkXwWPoIk4mFznmj6Cdzt


### PR DESCRIPTION
Adds two encryption types to S3. Either default server-side encryption (using [S3's managed key encryption method](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html)) or using [AWS KMS encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).

~~**Note** this PR is considered WIP because to support AWS KMS encryption, JVMs have to use the [Unlimited Strength JCE extension](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) and determining how best to incorporate that into this project is still up for debate.~~

We're doing KMS encryption on S3, not generating the key on the client.